### PR TITLE
Refactor

### DIFF
--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -155,7 +155,7 @@ class ServerDevice
         void Start(esp_gatt_if_t GATTinterface);
     public:
         ServerDevice();
-        ServerDevice(const char* Name, std::vector<Service*> Services);
+        ServerDevice(const char* Name, std::initializer_list<Service*> Services);
 
         void setGATTSevent(esp_gatts_cb_event_t Event, GATTScallbackType* Callback);
         

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -93,7 +93,7 @@ class Characteristic : public GATTinstance
         typedef void (*WriteCallback)(Characteristic*, const uint16_t, const void*);
         typedef void (*ReadCallback)(const Characteristic*, esp_ble_gatts_cb_param_t *param);
     
-        esp_attr_value_t  Char_Data;
+        esp_attr_value_t  CharData;
         const esp_gatt_perm_t Permition;
         const esp_gatt_char_prop_t Property;
 
@@ -114,20 +114,18 @@ class Characteristic : public GATTinstance
         
         void setReadCallback(ReadCallback call) { ReadHandler = call; }
         void setWriteCallback(WriteCallback call) { WriteHandler = call; }
-        
         void callReadCallback(esp_ble_gatts_cb_param_t *param);
         void callWriteCallback(esp_ble_gatts_cb_param_t *param);
 
         void setData(const void* Data, size_t DataSize);
         void setDynamicData(void* Data, size_t DataSize);
-        void* getData() const { return this->Data; }
-        size_t getDataSize() const { return this->DataSize; }
-
-        esp_err_t AttachToService(uint16_t ServiceHandler);
+        void* getData() const { return Data; }
+        size_t getDataSize() const { return DataSize; }
 
         void Notify(const void* Data, size_t DataSize, uint16_t connected_device_id = 0) const;
         void Responce(const void* Data, size_t DataSize, esp_ble_gatts_cb_param_t* Param) const;
 
+        void AttachToService(uint16_t ServiceHandler);
         static void setMTU(uint16_t);
 
         ~Characteristic();

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -59,6 +59,16 @@ class GATTinstance
         esp_bt_uuid_t UUID;
         uint16_t Handler;
     public:
+        GATTinstance(uint32_t ID)
+        {
+            UUID.len = ID & 0xFFFF0000 ? sizeof(uint32_t) : sizeof(uint16_t);
+            memcpy(&UUID.uuid, &ID, UUID.len);
+        }
+        GATTinstance(uint8_t ID[ESP_UUID_LEN_128])
+        {
+            UUID.len = ESP_UUID_LEN_128;
+            memcpy(&UUID.uuid, ID, UUID.len);
+        }
         #if defined BLE_SERVICES_PRINTF || defined BLE_CHARACTERISTICS_PRINTF
         void ConsoleInfoOut()
         {
@@ -79,12 +89,12 @@ class Characteristic : public GATTinstance
         typedef void GATTScallbackType(Characteristic*, esp_ble_gatts_cb_param_t*);
 
         esp_attr_value_t  Char_Data;
-        esp_gatt_perm_t Permition;
-        esp_gatt_char_prop_t Property;
+        const esp_gatt_perm_t Permition;
+        const esp_gatt_char_prop_t Property;
 
         bool DataAllocatedInsideObject = false;
-        void* Data;
-        size_t DataSize;
+        void* Data = nullptr;
+        size_t DataSize = 0;
         
         static void DefaultReadCallback(Characteristic*, esp_ble_gatts_cb_param_t*);
         GATTScallbackType* ReadHandler = &DefaultReadCallback;
@@ -116,16 +126,15 @@ class Service : public GATTinstance
     private:
         esp_gatt_srvc_id_t service_id;
         
-        uint16_t num_handle;
-        std::vector<Characteristic*> Characteristics;
-        size_t CharacteristicsSize;
+        const std::vector<Characteristic*> Characteristics;
+        const size_t CharacteristicsSize;
     public:
         uint16_t CharCounter = 0;
 
-        std::vector<Characteristic*> getCharacteristics() { return this->Characteristics; }
-        size_t getCharacteristicsSize() { return this->CharacteristicsSize; }
+        const std::vector<Characteristic*> getCharacteristics() const { return Characteristics; }
+        size_t getCharacteristicsSize() const { return CharacteristicsSize; }
 
-        Service(uint32_t _UUID, std::vector<Characteristic*> Characteristics);
+        Service(const uint32_t UUID, const std::vector<Characteristic*> Characteristics);
 
         void Start();
         void Create();

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -141,10 +141,10 @@ class ServerDevice
         static const uint8_t MaxEventNumber = 24;
         typedef void GATTScallbackType(ServerDevice*, esp_ble_gatts_cb_param_t*);
 
-        const char* Name;
-        esp_ble_adv_data_t AdvertisingData;
-        esp_ble_adv_data_t ScanResponceData;
-        esp_ble_adv_params_t AdvertisingParameters;
+        static const char* Name;
+        static esp_ble_adv_data_t AdvertisingData;
+        static esp_ble_adv_data_t ScanResponceData;
+        static esp_ble_adv_params_t AdvertisingParameters;
         esp_gatt_if_t GATTinterface;
 
         std::vector<Service*> Services;
@@ -155,8 +155,7 @@ class ServerDevice
         void Start(esp_gatt_if_t GATTinterface);
     public:
         ServerDevice();
-        ServerDevice(const char* Name, esp_ble_adv_data_t AdvertisingData, esp_ble_adv_data_t ScanResponceData, 
-                    esp_ble_adv_params_t AdvertisingParameters, std::vector<Service*> Services);
+        ServerDevice(const char* Name, std::vector<Service*> Services);
 
         void setGATTSevent(esp_gatts_cb_event_t Event, GATTScallbackType* Callback);
         

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -169,6 +169,9 @@ class ServerDevice
         static void HandleGAPevents(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
 
         static void Start();
+
+        static uint8_t serviceCounter;
+        static uint8_t charCounter;
     public:
         ServerDevice();
         ServerDevice(const char* Name, std::initializer_list<Service*> Services);
@@ -176,4 +179,6 @@ class ServerDevice
         void setGATTSevent(esp_gatts_cb_event_t Event, GATTScallbackType* Callback);
         void setGAPevent(esp_gap_ble_cb_event_t Event, GAPcallbackType* call);
 
+        static void Enable();
+        static void Disable();
 };

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -12,6 +12,7 @@
 
 #include <vector>
 #include <map>
+#include <cstring>
 
 #define BLE_SERVICES_PRINTF
 #define BLE_CHARACTERISTICS_PRINTF

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -154,25 +154,22 @@ class ServerDevice
 {
     private:
         static const uint8_t MaxEventNumber = 24;
-        typedef void GATTScallbackType(ServerDevice*, esp_ble_gatts_cb_param_t*);
 
         static const char* Name;
         static esp_ble_adv_data_t AdvertisingData;
         static esp_ble_adv_data_t ScanResponceData;
-        static esp_ble_adv_params_t AdvertisingParameters;
 
-        std::vector<Service*> Services;
-        
-        GATTScallbackType* DeviceCallbacks[MaxEventNumber] {NULL};
-        void HandleGATTSevents(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
+        static std::vector<Service*> Services;
 
-        void Start();
+        static GATTScallbackType* DeviceCallbacks[MaxEventNumber];
+        static void HandleGATTSevents(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
+
+        static void Start();
     public:
         ServerDevice();
         ServerDevice(const char* Name, std::initializer_list<Service*> Services);
 
         void setGATTSevent(esp_gatts_cb_event_t Event, GATTScallbackType* Callback);
-        
-        void HandleEvent(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t* param) 
-            { HandleGATTSevents(event, gatts_if, param); }
+
+        static esp_ble_adv_params_t AdvertisingParameters;
 };

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -124,17 +124,16 @@ class Characteristic : public GATTinstance
 class Service : public GATTinstance
 {
     private:
-        esp_gatt_srvc_id_t service_id;
+        esp_gatt_srvc_id_t serviceID;
         
         const std::vector<Characteristic*> Characteristics;
         const size_t CharacteristicsSize;
     public:
-        uint16_t CharCounter = 0;
-
         const std::vector<Characteristic*> getCharacteristics() const { return Characteristics; }
         size_t getCharacteristicsSize() const { return CharacteristicsSize; }
 
         Service(const uint32_t UUID, const std::vector<Characteristic*> Characteristics);
+        Service(uint8_t UUID[ESP_UUID_LEN_128], const std::vector<Characteristic*> Characteristics);
 
         void Start();
         void Create();

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -50,11 +50,12 @@ namespace Prop
     };
 }
 
+extern esp_gatt_if_t GATTinterface;
+
 class GATTinstance
 {
     protected:
         esp_bt_uuid_t UUID;
-        esp_gatt_if_t GATTinterface;
         uint16_t Handler;
     public:
         #if defined BLE_SERVICES_PRINTF || defined BLE_CHARACTERISTICS_PRINTF
@@ -69,10 +70,6 @@ class GATTinstance
         
         uint16_t getHandler() { return this->Handler; }
         void setHandler(uint16_t Handler) { this->Handler = Handler; }
-        
-        esp_gatt_if_t getGATTinterface() { return this->GATTinterface; }
-        void setGATTinterface(esp_gatt_if_t GATTinterface) { this->GATTinterface = GATTinterface; }
-
 };
 
 class Characteristic : public GATTinstance
@@ -124,8 +121,6 @@ class Service : public GATTinstance
     public:
         uint16_t CharCounter = 0;
 
-        void setGATTinterface(esp_gatt_if_t GATTinterface);
-
         std::vector<Characteristic*> getCharacteristics() { return this->Characteristics; }
         size_t getCharacteristicsSize() { return this->CharacteristicsSize; }
 
@@ -145,14 +140,13 @@ class ServerDevice
         static esp_ble_adv_data_t AdvertisingData;
         static esp_ble_adv_data_t ScanResponceData;
         static esp_ble_adv_params_t AdvertisingParameters;
-        esp_gatt_if_t GATTinterface;
 
         std::vector<Service*> Services;
         
         GATTScallbackType* DeviceCallbacks[MaxEventNumber] {NULL};
         void HandleGATTSevents(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
 
-        void Start(esp_gatt_if_t GATTinterface);
+        void Start();
     public:
         ServerDevice();
         ServerDevice(const char* Name, std::initializer_list<Service*> Services);

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -61,12 +61,9 @@ class GATTinstance
         void ConsoleInfoOut()
         {
             printf("UUID: ");
-            if(this->UUID.len == ESP_UUID_LEN_16)
-                printf("%04X, ", this->UUID.uuid.uuid16);
-            else if(this->UUID.len == ESP_UUID_LEN_32)
-                printf("%08X, ", this->UUID.uuid.uuid32);
-
-            printf("Handler: %d\n", this->Handler);
+            for(uint8_t i = 0; i < UUID.len; ++i)
+                printf("%02X", UUID.uuid.uuid128[i]);
+            printf(", Handler: %d\n", this->Handler);
         }
         #endif
         

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -18,6 +18,10 @@
 #define BLE_CHARACTERISTICS_PRINTF
 #define BLE_INPUT_PRINTF
 
+#ifdef BLE_INPUT_PRINTF
+    #define MAX_OUTPUT_AMOUNT 40
+#endif
+
 typedef __uint8_t byte;
 
 namespace Perm
@@ -103,8 +107,11 @@ class Characteristic : public GATTinstance
         WriteCallback WriteHandler = [](Characteristic* ch, const uint16_t len, const void* value){
             ch->setData(value, len);
         };
-
+        static uint16_t MTU;
     public:
+        Characteristic(uint32_t _UUID, esp_gatt_perm_t, esp_gatt_char_prop_t);
+        Characteristic(uint8_t _UUID[ESP_UUID_LEN_128], esp_gatt_perm_t, esp_gatt_char_prop_t);
+        
         void setReadCallback(ReadCallback call) { ReadHandler = call; }
         void setWriteCallback(WriteCallback call) { WriteHandler = call; }
         
@@ -121,8 +128,9 @@ class Characteristic : public GATTinstance
         void Notify(const void* Data, size_t DataSize, uint16_t connected_device_id = 0) const;
         void Responce(const void* Data, size_t DataSize, esp_ble_gatts_cb_param_t* Param) const;
 
-        Characteristic(uint32_t _UUID, esp_gatt_perm_t, esp_gatt_char_prop_t);
-        Characteristic(uint8_t _UUID[ESP_UUID_LEN_128], esp_gatt_perm_t, esp_gatt_char_prop_t);
+        static void setMTU(uint16_t);
+
+        ~Characteristic();
 };
 
 class Service : public GATTinstance

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -149,6 +149,7 @@ class Service : public GATTinstance
         void Create();
 };
 
+typedef void GATTScallbackType(esp_ble_gatts_cb_param_t*);
 class ServerDevice
 {
     private:

--- a/inc/Bluetooth.hpp
+++ b/inc/Bluetooth.hpp
@@ -150,19 +150,23 @@ class Service : public GATTinstance
 };
 
 typedef void GATTScallbackType(esp_ble_gatts_cb_param_t*);
+typedef void GAPcallbackType(esp_ble_gap_cb_param_t*);
 class ServerDevice
 {
     private:
         static const uint8_t MaxEventNumber = 24;
 
         static const char* Name;
+        static esp_ble_adv_params_t AdvertisingParameters;
         static esp_ble_adv_data_t AdvertisingData;
         static esp_ble_adv_data_t ScanResponceData;
 
         static std::vector<Service*> Services;
 
         static GATTScallbackType* DeviceCallbacks[MaxEventNumber];
+        static GAPcallbackType* GAPcalls[ESP_GAP_BLE_EVT_MAX];
         static void HandleGATTSevents(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
+        static void HandleGAPevents(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
 
         static void Start();
     public:
@@ -170,6 +174,6 @@ class ServerDevice
         ServerDevice(const char* Name, std::initializer_list<Service*> Services);
 
         void setGATTSevent(esp_gatts_cb_event_t Event, GATTScallbackType* Callback);
+        void setGAPevent(esp_gap_ble_cb_event_t Event, GAPcallbackType* call);
 
-        static esp_ble_adv_params_t AdvertisingParameters;
 };

--- a/src/Bluetooth_Characteristic.cpp
+++ b/src/Bluetooth_Characteristic.cpp
@@ -1,6 +1,9 @@
 #include <Bluetooth.hpp>
 
-#define MAX_MTU 512
+#define MAX_MTU 517
+#define MIN_MTU 23
+#define getCorrectSize(size) size > MTU ? MTU : size
+uint16_t Characteristic::MTU = MIN_MTU;
 
 Characteristic::Characteristic(uint32_t ID, esp_gatt_perm_t Permition, esp_gatt_char_prop_t Property)
     : GATTinstance(ID), Permition(Permition), Property(Property)
@@ -98,11 +101,21 @@ void Characteristic::setData(const void* Data, size_t DataSize)
 void Characteristic::setDynamicData(void* Data, size_t DataSize)
 {
     if(this->Data && DataAllocatedInsideObject)
-    {
-        byte* DataToClear = (byte*)this->Data;
-        delete[] DataToClear;
-    }
+        delete[] (uint8_t*)this->Data;
+    this->DataSize = getCorrectSize(DataSize);
+
     this->Data = Data;
-    this->DataSize = DataSize;
     DataAllocatedInsideObject = false;
+}
+
+void Characteristic::setMTU(uint16_t MTU)
+{
+    if(MTU <= MAX_MTU && MTU >= MIN_MTU)
+        Characteristic::MTU = MTU;
+}
+
+Characteristic::~Characteristic()
+{
+    if(this->Data && DataAllocatedInsideObject)
+        delete[] (uint8_t*)this->Data;
 }

--- a/src/Bluetooth_Characteristic.cpp
+++ b/src/Bluetooth_Characteristic.cpp
@@ -1,5 +1,4 @@
 #include <Bluetooth.hpp>
-#include <cstring>
 
 #define MAX_MTU 512
 

--- a/src/Bluetooth_Characteristic.cpp
+++ b/src/Bluetooth_Characteristic.cpp
@@ -14,27 +14,27 @@ Characteristic::Characteristic(uint8_t ID[ESP_UUID_LEN_128], esp_gatt_perm_t Per
 {
 }
 
+static inline void AddNotificationDescriptor(uint16_t ServiceHandler)
+{
+    
+    static esp_bt_uuid_t DescriptorUUID{
+        .len = ESP_UUID_LEN_16,
+        { .uuid16 = ESP_GATT_UUID_CHAR_CLIENT_CONFIG, }
+    };
+
+    esp_ble_gatts_add_char_descr(ServiceHandler, &DescriptorUUID,  
+        Perm::Read | Perm::Write, NULL, NULL);
+}
+
 /**
  * @brief Create association with Service
 */
-esp_err_t Characteristic::AttachToService(uint16_t ServiceHandler)
+void Characteristic::AttachToService(uint16_t ServiceHandler)
 {
-    esp_err_t ret;
-    ret = esp_ble_gatts_add_char(ServiceHandler, &UUID, Permition, Property, &Char_Data, NULL);
+    esp_ble_gatts_add_char(ServiceHandler, &UUID, Permition, Property, &CharData, NULL);
     
-    //  Add descriptor for notifications
     if(Property & ESP_GATT_CHAR_PROP_BIT_NOTIFY)
-    {
-        esp_bt_uuid_t DESCR_DATA_UUID;
-            DESCR_DATA_UUID.len = ESP_UUID_LEN_16;
-            DESCR_DATA_UUID.uuid.uuid16 = ESP_GATT_UUID_CHAR_CLIENT_CONFIG; 
-
-        ret |= esp_ble_gatts_add_char_descr(ServiceHandler, &DESCR_DATA_UUID, 
-                                    ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE,
-                                    NULL,
-                                    NULL);
-    }
-    return ret;
+        AddNotificationDescriptor(ServiceHandler);
 }
 
 void Characteristic::callReadCallback(esp_ble_gatts_cb_param_t *param)
@@ -56,47 +56,37 @@ void Characteristic::Responce(const void* Data, size_t DataSize, esp_ble_gatts_c
     static esp_gatt_rsp_t rsp;
     
     rsp.handle = Handler;
-    rsp.attr_value.len = DataSize;
-    memcpy(rsp.attr_value.value, Data, DataSize);
+    rsp.attr_value.len = getCorrectSize(DataSize);
+    memcpy(rsp.attr_value.value, Data, rsp.attr_value.len);
 
     esp_ble_gatts_send_response(GATTinterface, Param->read.conn_id, Param->read.trans_id, ESP_GATT_OK, &rsp);
 }
 
 /**
- * @brief Notify client with data array
- * @param Data Byte array
- * @param DataSize Number of elements in the array
- * @param ConnectedDeviceID ID of connection
+ * @brief Notify without confirmation
  */ 
 void Characteristic::Notify(const void* Data, size_t DataSize, uint16_t ConnectedDeviceID) const
 {
     if(Property & ESP_GATT_CHAR_PROP_BIT_NOTIFY)
-        esp_ble_gatts_send_indicate(GATTinterface, ConnectedDeviceID, Handler, DataSize, (byte*)Data, false);
+        esp_ble_gatts_send_indicate(GATTinterface, ConnectedDeviceID, Handler, getCorrectSize(DataSize), (uint8_t*)Data, false);
 }
 
 /**
- * @brief Set Inner Characteristic Data by copying. Overwrites old data
- * @param Data Array that will be copied into object's field
- * @param DataSize Size, maximum value - 516
+ * @brief Allocate array inside object and copy data to it
  */
 void Characteristic::setData(const void* Data, size_t DataSize)
 {
     if(this->Data && DataAllocatedInsideObject)
-    {
-        byte* DataToClear = (byte*)this->Data;
-        delete[] DataToClear;
-    }
-    DataSize = DataSize > (ESP_GATT_MAX_MTU_SIZE - 1) ? ESP_GATT_MAX_MTU_SIZE - 1 : DataSize;
-    this->Data = new byte[DataSize];
-    this->DataSize = DataSize;
-    
+        delete[] (uint8_t*)this->Data;
+    this->DataSize = getCorrectSize(DataSize);
+
+    this->Data = new byte[DataSize];    
     memcpy(this->Data, Data, this->DataSize);
     DataAllocatedInsideObject = true;
 }
 /**
- * @brief Set Extern Characteristic Data by reference
- * @param Data Dyncamic data allocated outside of class, DO NOT delete if characterisitc will refer it
- * @param DataSize Size, has no maximum value
+ * @brief Set reference to data allocated by caller. DO NOT delete data while 
+ * it is being referenced, if you don't look for a trouble
 */
 void Characteristic::setDynamicData(void* Data, size_t DataSize)
 {

--- a/src/Bluetooth_Characteristic.cpp
+++ b/src/Bluetooth_Characteristic.cpp
@@ -41,38 +41,14 @@ void Characteristic::callReadCallback(esp_ble_gatts_cb_param_t *param)
 
 void Characteristic::callWriteCallback(esp_ble_gatts_cb_param_t *param)
 {
-    WriteHandler(this, param);
+    WriteHandler(this, param->write.len, param->write.value);
 }
 
-/**
- * @brief Responce with Characteristic::Data
-*/
-void Characteristic::DefaultReadCallback(Characteristic* ch, esp_ble_gatts_cb_param_t *param)
-{
-    void* data = ch->getData();
-    size_t size;
-    if(!data)
-        size = 0;
-    else
-    {    
-        size = ch->getDataSize();
-        size = size > MAX_MTU ? MAX_MTU : size;
-    }
-    ch->Responce(data, size, param);
-}
-
-/**
- * @brief Copy input to Characteristic::Data
-*/
-void Characteristic::DefaultWriteCallback(Characteristic* ch, esp_ble_gatts_cb_param_t *param)
-{
-    ch->setData(param->write.value, param->write.len);
-}
 
 /**
  * @brief Answer to read request
 */
-void Characteristic::Responce(const void* Data, size_t DataSize, esp_ble_gatts_cb_param_t* Param)
+void Characteristic::Responce(const void* Data, size_t DataSize, esp_ble_gatts_cb_param_t* Param) const
 {
     static esp_gatt_rsp_t rsp;
     
@@ -89,9 +65,9 @@ void Characteristic::Responce(const void* Data, size_t DataSize, esp_ble_gatts_c
  * @param DataSize Number of elements in the array
  * @param ConnectedDeviceID ID of connection
  */ 
-void Characteristic::Notify(const void* Data, size_t DataSize, uint16_t ConnectedDeviceID)
+void Characteristic::Notify(const void* Data, size_t DataSize, uint16_t ConnectedDeviceID) const
 {
-    if(this->Property & ESP_GATT_CHAR_PROP_BIT_NOTIFY)
+    if(Property & ESP_GATT_CHAR_PROP_BIT_NOTIFY)
         esp_ble_gatts_send_indicate(GATTinterface, ConnectedDeviceID, Handler, DataSize, (byte*)Data, false);
 }
 

--- a/src/Bluetooth_Characteristic.cpp
+++ b/src/Bluetooth_Characteristic.cpp
@@ -2,27 +2,13 @@
 
 #define MAX_MTU 512
 
-Characteristic::Characteristic(uint32_t _UUID, esp_gatt_perm_t Permition, esp_gatt_char_prop_t Property)
+Characteristic::Characteristic(uint32_t ID, esp_gatt_perm_t Permition, esp_gatt_char_prop_t Property)
+    : GATTinstance(ID), Permition(Permition), Property(Property)
 {
-    this->UUID.len = _UUID & 0xFFFF0000 ? sizeof(uint32_t) : sizeof(uint16_t);
-    memcpy(&this->UUID.uuid, &_UUID, this->UUID.len);
-
-    this->Data = nullptr;
-    this->DataSize = 0;
-    this->Permition = Permition;
-    this->Property = Property;
-
 }
-Characteristic::Characteristic(uint8_t _UUID[ESP_UUID_LEN_128], esp_gatt_perm_t Permition, esp_gatt_char_prop_t Property)
+Characteristic::Characteristic(uint8_t ID[ESP_UUID_LEN_128], esp_gatt_perm_t Permition, esp_gatt_char_prop_t Property)
+    : GATTinstance(ID), Permition(Permition), Property(Property)
 {
-    memcpy(this->UUID.uuid.uuid128, _UUID, ESP_UUID_LEN_128);
-    
-    this->UUID.len = ESP_UUID_LEN_128;
-    this->Data = nullptr;
-    this->DataSize = 0;
-
-    this->Permition = Permition;
-    this->Property = Property;
 }
 
 /**
@@ -34,7 +20,7 @@ esp_err_t Characteristic::AttachToService(uint16_t ServiceHandler)
     ret = esp_ble_gatts_add_char(ServiceHandler, &UUID, Permition, Property, &Char_Data, NULL);
     
     //  Add descriptor for notifications
-    if(this->Property & ESP_GATT_CHAR_PROP_BIT_NOTIFY)
+    if(Property & ESP_GATT_CHAR_PROP_BIT_NOTIFY)
     {
         esp_bt_uuid_t DESCR_DATA_UUID;
             DESCR_DATA_UUID.len = ESP_UUID_LEN_16;
@@ -50,12 +36,12 @@ esp_err_t Characteristic::AttachToService(uint16_t ServiceHandler)
 
 void Characteristic::callReadCallback(esp_ble_gatts_cb_param_t *param)
 {
-    this->ReadHandler(this, param);
+    ReadHandler(this, param);
 }
 
 void Characteristic::callWriteCallback(esp_ble_gatts_cb_param_t *param)
 {
-    this->WriteHandler(this, param);
+    WriteHandler(this, param);
 }
 
 /**

--- a/src/Bluetooth_ServerDevice.cpp
+++ b/src/Bluetooth_ServerDevice.cpp
@@ -3,30 +3,65 @@
 
 ServerDevice::ServerDevice() {}
 
-ServerDevice::ServerDevice(const char* Name, esp_ble_adv_data_t AdvertisingData, esp_ble_adv_data_t ScanResponceData,
-                            esp_ble_adv_params_t AdvertisingParameters, std::vector<Service*> Services)
+const char* ServerDevice::Name = "None";
+esp_ble_adv_data_t ServerDevice::AdvertisingData = {
+    .set_scan_rsp = false,
+    .include_name = true,
+    .include_txpower = false,
+    .min_interval = 0x0006, //slave connection min interval, Time = min_interval * 1.25 msec
+    .max_interval = 0x0010, //slave connection max interval, Time = max_interval * 1.25 msec
+    .appearance = 0x00,
+    .manufacturer_len = 0, //TEST_MANUFACTURER_DATA_LEN,
+    .p_manufacturer_data =  NULL, //&test_manufacturer[0],
+    .service_data_len = 0,
+    .p_service_data = NULL,
+    .service_uuid_len = sizeof(adv_service_uuid128),
+    .p_service_uuid = adv_service_uuid128,
+    .flag = (ESP_BLE_ADV_FLAG_GEN_DISC | ESP_BLE_ADV_FLAG_BREDR_NOT_SPT),
+};
+
+esp_ble_adv_data_t ServerDevice::ScanResponceData = {
+    .set_scan_rsp = true,
+    .include_name = true,
+    .include_txpower = true,
+    //.min_interval = 0x0006,
+    //.max_interval = 0x0010,
+    .appearance = 0x00,
+    .manufacturer_len = 0, //TEST_MANUFACTURER_DATA_LEN,
+    .p_manufacturer_data =  NULL, //&test_manufacturer[0],
+    .service_data_len = 0,
+    .p_service_data = NULL,
+    .service_uuid_len = sizeof(adv_service_uuid128),
+    .p_service_uuid = adv_service_uuid128,
+    .flag = (ESP_BLE_ADV_FLAG_GEN_DISC | ESP_BLE_ADV_FLAG_BREDR_NOT_SPT),
+};
+
+esp_ble_adv_params_t ServerDevice::AdvertisingParameters = {
+    .adv_int_min        = 0x20,
+    .adv_int_max        = 0x40,
+    .adv_type           = ADV_TYPE_IND,
+    .own_addr_type      = BLE_ADDR_TYPE_PUBLIC,
+    //.peer_addr            =
+    //.peer_addr_type       =
+    .channel_map        = ADV_CHNL_ALL,
+    .adv_filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
+};
+
+
+ServerDevice::ServerDevice(const char* Name, std::vector<Service*> Services)
 {
     this->Name = Name;
-    this->AdvertisingData = AdvertisingData;
-    this->ScanResponceData = ScanResponceData;
-    this->AdvertisingParameters = AdvertisingParameters;
 
     this->Services = Services;
 
     ESP_ERROR_CHECK(esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT));
 
     esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-    if(esp_bt_controller_init(&bt_cfg) == ESP_OK)
-        printf("Controller Initialized\n");
-
-    if(esp_bt_controller_enable(ESP_BT_MODE_BLE) == ESP_OK)
-        printf("Controller Enabled\n");
     
-    if(esp_bluedroid_init() == ESP_OK)
-        printf("Bluedroid Initialized\n");
-    
-    if(esp_bluedroid_enable() == ESP_OK)
-        printf("Bluedroid Enabled\n");
+    esp_bt_controller_init(&bt_cfg);
+    esp_bt_controller_enable(ESP_BT_MODE_BLE);
+    esp_bluedroid_init();
+    esp_bluedroid_enable();
 }
 
 /**

--- a/src/Bluetooth_ServerDevice.cpp
+++ b/src/Bluetooth_ServerDevice.cpp
@@ -47,12 +47,11 @@ esp_ble_adv_params_t ServerDevice::AdvertisingParameters = {
     .adv_filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
 };
 
-
-ServerDevice::ServerDevice(const char* Name, std::vector<Service*> Services)
+ServerDevice::ServerDevice(const char* Name, std::initializer_list<Service*> ServiceList)
 {
     this->Name = Name;
-
-    this->Services = Services;
+    for(auto service : ServiceList)
+        Services.push_back(service);
 
     ESP_ERROR_CHECK(esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT));
 

--- a/src/Bluetooth_ServerDevice.cpp
+++ b/src/Bluetooth_ServerDevice.cpp
@@ -1,10 +1,15 @@
 #include <Bluetooth.hpp>
-#include <BluetoothGAP.h>
 
 ServerDevice::ServerDevice() {}
 
 esp_gatt_if_t GATTinterface = 0;
 const char* ServerDevice::Name = "None";
+static uint8_t adv_service_uuid128[] = 
+{
+    0xfb, 0x34, 0x9b, 0x5f, 0x80, 0x00, 0x00, 0x80, 
+    0x00, 0x10, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00,
+};
+
 esp_ble_adv_data_t ServerDevice::AdvertisingData = {
     .set_scan_rsp = false,
     .include_name = true,
@@ -126,7 +131,7 @@ void ServerDevice::HandleGATTSevents(esp_gatts_cb_event_t event, esp_gatt_if_t g
         break;
     case ESP_GATTS_DISCONNECT_EVT:
         printf("Disconnected!\n");
-        esp_ble_gap_start_advertising(&adv_params);
+        esp_ble_gap_start_advertising(&AdvertisingParameters);
         break;
 
     case ESP_GATTS_CONNECT_EVT: 

--- a/src/Bluetooth_ServerDevice.cpp
+++ b/src/Bluetooth_ServerDevice.cpp
@@ -189,6 +189,7 @@ void ServerDevice::HandleGATTSevents(esp_gatts_cb_event_t event, esp_gatt_if_t g
     }
     case ESP_GATTS_MTU_EVT:
         printf("New MTU size: %d\n", param->mtu.mtu);
+        Characteristic::setMTU(param->mtu.mtu);
         break;
     case ESP_GATTS_UNREG_EVT:
     case ESP_GATTS_ADD_INCL_SRVC_EVT:

--- a/src/Bluetooth_Service.cpp
+++ b/src/Bluetooth_Service.cpp
@@ -1,5 +1,4 @@
 #include <Bluetooth.hpp>
-#include <cstring>
 
 Service::Service(uint32_t _UUID, std::vector<Characteristic*> Characteristics)
 {

--- a/src/Bluetooth_Service.cpp
+++ b/src/Bluetooth_Service.cpp
@@ -17,22 +17,12 @@ Service::Service(uint32_t _UUID, std::vector<Characteristic*> Characteristics)
 void Service::Create()
 {
     this->num_handle = 4 + (CharacteristicsSize << 1);
-    esp_ble_gatts_create_service(this->GATTinterface, &service_id, num_handle);
+    esp_ble_gatts_create_service(GATTinterface, &service_id, num_handle);
 }
 
 void Service::Start()
 {
-    esp_ble_gatts_start_service(this->Handler);
+    esp_ble_gatts_start_service(Handler);
     for(size_t i = 0; i < CharacteristicsSize; i++)
-    {
-        Characteristics[i]->AttachToService(this->Handler);
-        Characteristics[i]->setGATTinterface(this->GATTinterface);
-    }
-}
-
-void Service::setGATTinterface(esp_gatt_if_t GATTinterface)
-{ 
-    this->GATTinterface = GATTinterface; 
-    for(size_t i = 0; i < CharacteristicsSize; i++)
-        Characteristics[i]->setGATTinterface(GATTinterface);
+        Characteristics[i]->AttachToService(Handler);
 }

--- a/src/Bluetooth_Service.cpp
+++ b/src/Bluetooth_Service.cpp
@@ -3,14 +3,22 @@
 Service::Service(const uint32_t ID, const std::vector<Characteristic*> Characteristics)
     : GATTinstance(ID), Characteristics(Characteristics), CharacteristicsSize(Characteristics.size())
 {
-    service_id.is_primary = true;
-    service_id.id.inst_id = 0x00;
-    service_id.id.uuid = UUID;
+    serviceID.is_primary = true;
+    serviceID.id.inst_id = 0x00;
+    serviceID.id.uuid = UUID;
+}
+
+Service::Service(uint8_t ID[ESP_UUID_LEN_128], const std::vector<Characteristic*> Characteristics)
+    : GATTinstance(ID), Characteristics(Characteristics), CharacteristicsSize(Characteristics.size())
+{
+    serviceID.is_primary = true;
+    serviceID.id.inst_id = 0x00;
+    serviceID.id.uuid = UUID;
 }
 
 void Service::Create()
 {
-    esp_ble_gatts_create_service(GATTinterface, &service_id, 4 + (CharacteristicsSize << 1));
+    esp_ble_gatts_create_service(GATTinterface, &serviceID, 4 + (CharacteristicsSize << 1));
 }
 
 void Service::Start()

--- a/src/Bluetooth_Service.cpp
+++ b/src/Bluetooth_Service.cpp
@@ -1,27 +1,21 @@
 #include <Bluetooth.hpp>
 
-Service::Service(uint32_t _UUID, std::vector<Characteristic*> Characteristics)
+Service::Service(const uint32_t ID, const std::vector<Characteristic*> Characteristics)
+    : GATTinstance(ID), Characteristics(Characteristics), CharacteristicsSize(Characteristics.size())
 {
-    this->service_id.is_primary = true;
-    this->service_id.id.inst_id = 0x00;
-    
-    this->UUID.len = _UUID & 0xFFFF0000 ? sizeof(uint32_t) : sizeof(uint16_t);
-    memcpy(&this->UUID.uuid, &_UUID, this->UUID.len);
-    this->service_id.id.uuid = this->UUID;
-
-    this->Characteristics = Characteristics;
-    this->CharacteristicsSize = Characteristics.size();
+    service_id.is_primary = true;
+    service_id.id.inst_id = 0x00;
+    service_id.id.uuid = UUID;
 }
 
 void Service::Create()
 {
-    this->num_handle = 4 + (CharacteristicsSize << 1);
-    esp_ble_gatts_create_service(GATTinterface, &service_id, num_handle);
+    esp_ble_gatts_create_service(GATTinterface, &service_id, 4 + (CharacteristicsSize << 1));
 }
 
 void Service::Start()
 {
     esp_ble_gatts_start_service(Handler);
-    for(size_t i = 0; i < CharacteristicsSize; i++)
-        Characteristics[i]->AttachToService(Handler);
+    for(auto ch : Characteristics)
+        ch->AttachToService(Handler);
 }


### PR DESCRIPTION
- Refactor each class
- Add constructor to GATTinstance
- Replace std::vector constructors with std::initializer_list ones
- Make Characteristic check dynamic static MTU instead of a const one
- Make GATT interface static and same for all of the library objects - remove tree of setGATTinterface calls
- Make ServerDevice static, thus there's no more need for user to point to ServerDevice's GATTS event handler. It is being set inside class.